### PR TITLE
Resolve build error of ai_src/Makefile_Linux by avoiding BSS segment overflow

### DIFF
--- a/ai_src/Makefile_Linux
+++ b/ai_src/Makefile_Linux
@@ -1,6 +1,6 @@
 COMPILER = g++
 NPROCS = $(shell grep -c ^processor /proc/cpuinfo)
-CFLAGS = -g -MMD -MP -std=c++11 -O3 -fopenmp -pthread -fPIC -DNPROCS=$(NPROCS)
+CFLAGS = -g -MMD -MP -std=c++11 -O3 -fopenmp -pthread -fPIC -DNPROCS=$(NPROCS) -mcmodel=medium
 WFLAGS = -pedantic -Wignored-qualifiers -Wreturn-type -Wmaybe-uninitialized -Wbool-compare -Wshadow -Wunused-but-set-variable -Wunused-variable
 LIBS = -lboost_system
 


### PR DESCRIPTION
Building Linux binary with Ubuntu in WSL2 fails by following error when linking ai_src lib:
```
g++ -shared ./obj/yaku_pattern.o ./obj/betaori.o ./obj/combination.o ./obj/mjutil.o ./obj/tactics.o ./obj/jun_calc.o ./obj/tehai_action.o ./obj/tehai_inout_pattern.o ./obj/tenpai_est.o ./obj/tehai_ana.o ./obj/tehai_cal_supl.o ./obj/tehai_state2.o ./obj/tehai_cal_work.o ./obj/selector.o ./obj/ankan_after_reach.o ./obj/agari.o ./obj/yaku_dist.o ./obj/tehai_cal.o ./obj/tehai_change.o ./obj/bit_hai_num.o ./obj/tehai_group.o ./obj/tehai_pat.o ./obj/tenpai_prob_calc.o ./obj/exp_values.o ./../share/obj/agari_ten.o ./../share/obj/include.o ./../share/obj/make_move.o ./../share/obj/calc_agari.o ./../share/obj/types.o ./../share/obj/json11.o ./../share/obj/calc_yaku.o ./../share/obj/calc_shanten.o  -g -MMD -MP -std=c++11 -O3 -fopenmp -pthread -fPIC -DNPROCS=16 -pedantic -Wignored-qualifiers -Wreturn-type -Wmaybe-uninitialized -Wbool-compare -Wshadow -Wunused-but-set-variable -Wunused-variable -lboost_system -o libai.so
./obj/selector.o: in function `_GLOBAL__sub_I_selector.cpp':
/usr/include/c++/9/iostream:74:(.text.startup+0x9): relocation truncated to fit: R_X86_64_PC32 against `.bss'
(snip)
/usr/include/c++/9/iostream:74:(.text.startup+0x8): additional relocation overflows omitted from the output
collect2: error: ld returned 1 exit status
make: *** [Makefile_Linux:43: libai.so] Error 1
```
Since BSS segmento doesn't fit the required size, I added -mcmodel flag to the CFLAGS and the issue is solved.
FYI, My building environment is as follows:
``
Linux DESKTOP-******** 5.10.16.3-microsoft-standard-WSL2 #1 SMP Fri Apr 2 22:23:49 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04)
GNU ld (GNU Binutils for Ubuntu) 2.34
-- 
Thank you.