### PR TITLE
Compatibility and performance fixes for Makefile 

### DIFF
--- a/Makefile_MacOS
+++ b/Makefile_MacOS
@@ -1,5 +1,5 @@
-LLVM_BASE = $(shell brew --prefix llvm)
-BOOST_BASE = $(shell brew --prefix boost)
+LLVM_BASE := $(shell brew --prefix llvm)
+BOOST_BASE := $(shell brew --prefix boost)
 
 COMPILER = $(LLVM_BASE)/bin/clang++
 CFLAGS = -g -MMD -MP -std=c++11 \

--- a/Makefile_MacOS
+++ b/Makefile_MacOS
@@ -1,9 +1,16 @@
 LLVM_BASE := $(shell brew --prefix llvm)
 BOOST_BASE := $(shell brew --prefix boost)
+CPU_BRAND := $(shell sysctl -n machdep.cpu.brand_string)
+
+ifneq (,$(findstring Apple,$(CPU_BRAND)))
+	CPU_FLAGS := -mcpu=apple-m1
+else
+	CPU_FLAGS := -march=native
+endif
 
 COMPILER = $(LLVM_BASE)/bin/clang++
 CFLAGS = -g -MMD -MP -std=c++11 \
-	-O3 -march=native -pipe \
+	-O3 $(CPU_FLAGS) -pipe \
 	-mllvm -polly \
 	-mllvm -polly-parallel \
 	-mllvm -polly-vectorizer=stripmine \

--- a/ai_src/Makefile_Linux
+++ b/ai_src/Makefile_Linux
@@ -1,5 +1,5 @@
 COMPILER = g++
-NPROCS = $(shell grep -c ^processor /proc/cpuinfo)
+NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
 CFLAGS = -g -MMD -MP -std=c++11 -O3 -fopenmp -pthread -fPIC -DNPROCS=$(NPROCS) -mcmodel=medium
 WFLAGS = -pedantic -Wignored-qualifiers -Wreturn-type -Wmaybe-uninitialized -Wbool-compare -Wshadow -Wunused-but-set-variable -Wunused-variable
 LIBS = -lboost_system

--- a/ai_src/Makefile_MacOS
+++ b/ai_src/Makefile_MacOS
@@ -1,10 +1,17 @@
 LLVM_BASE := $(shell brew --prefix llvm)
 BOOST_BASE := $(shell brew --prefix boost)
+CPU_BRAND := $(shell sysctl -n machdep.cpu.brand_string)
+
+ifneq (,$(findstring Apple,$(CPU_BRAND)))
+	CPU_FLAGS := -mcpu=apple-m1
+else
+	CPU_FLAGS := -march=native
+endif
 
 COMPILER = $(LLVM_BASE)/bin/clang++
 NPROCS := $(shell sysctl -n hw.ncpu)
 CFLAGS = -g -MMD -MP -std=c++11 \
-	-O3 -march=native -pipe \
+	-O3 $(CPU_FLAGS) -pipe \
 	-mllvm -polly \
 	-mllvm -polly-parallel \
 	-mllvm -polly-vectorizer=stripmine \

--- a/ai_src/Makefile_MacOS
+++ b/ai_src/Makefile_MacOS
@@ -1,8 +1,8 @@
-LLVM_BASE = $(shell brew --prefix llvm)
-BOOST_BASE = $(shell brew --prefix boost)
+LLVM_BASE := $(shell brew --prefix llvm)
+BOOST_BASE := $(shell brew --prefix boost)
 
 COMPILER = $(LLVM_BASE)/bin/clang++
-NPROCS = $(shell sysctl -n hw.ncpu)
+NPROCS := $(shell sysctl -n hw.ncpu)
 CFLAGS = -g -MMD -MP -std=c++11 \
 	-O3 -march=native -pipe \
 	-mllvm -polly \


### PR DESCRIPTION
## Performance improvement (d79b1f9c40271c767528d7ad38a5f15d9e0d71df)
- Use simple assignment (`:=` instead of `=`) to avoid repeated shell commands.
- About how it works: [Makefile Optimization: $(shell) and := go Together](https://www.cmcrossroads.com/article/makefile-optimization-shell-and-go-together).

## CPU flags on Apple Silicon (249ad997cf1448eafe59d305eb91f6225b4c4ceb)
- `-march=native` does not work on Apple M1; use `-mcpu=apple-m1` instead.
- Reference: [Why does march=native not work on Apple M1?](https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1).
- My device is an MacBook Pro 13'' with Apple M1. This fix worked for me.